### PR TITLE
fix: use entityType option

### DIFF
--- a/src/customerlocationentity.js
+++ b/src/customerlocationentity.js
@@ -22,9 +22,8 @@ const entity = new EventSourcedEntity(
     "wirelessmesh.proto"
   ],
   "wirelessmesh.WirelessMeshService",
-  "wirelessmeshservice",
+  "customer-location-entity",
   {
-    entityType: "customer-location-entity",
     includeDirs: ["./proto"],
     serializeFallbackToJson: true
   }

--- a/src/customerlocationentity.js
+++ b/src/customerlocationentity.js
@@ -24,7 +24,7 @@ const entity = new EventSourcedEntity(
   "wirelessmesh.WirelessMeshService",
   "wirelessmeshservice",
   {
-    persistenceId: "customer-location-entity",
+    entityType: "customer-location-entity",
     includeDirs: ["./proto"],
     serializeFallbackToJson: true
   }


### PR DESCRIPTION
This will allow the actions and views to subscribe to the event sourced entity event log.

Note that this will uncover the next issues: that events are JSON and going to the CatchOthers methods, and that the view doesn't implement a catch others.

Running with `DEBUG=akkaserverless*` will enable the JavaScript SDK logging.