### PR TITLE
using protobuf messages for events

### DIFF
--- a/src/customerlocationentity.js
+++ b/src/customerlocationentity.js
@@ -29,6 +29,10 @@ const entity = new EventSourcedEntity(
   }
 );
 
+const domain = {
+  CustomerLocationAdded: entity.lookupType("wirelessmeshdomain.CustomerLocationAdded")
+}
+
 /*
  * Set a callback to create the initial state. This is what is created if there is no
  * snapshot to load.
@@ -91,12 +95,11 @@ function addCustomerLocation(addCustomerLocationCommand, entityState, ctx) {
   }
   else {
     // Create the event.
-    const customerLocationAdded = {
-      type: "CustomerLocationAdded",
+    const customerLocationAdded = domain.CustomerLocationAdded.create({
       customerLocationId: addCustomerLocationCommand.customerLocationId,
       accessToken: addCustomerLocationCommand.accessToken,
       email: addCustomerLocationCommand.email
-    };
+    });
     // Emit the event.
     ctx.emit(customerLocationAdded);
     return {};


### PR DESCRIPTION
Fix google pubsub

that will work for just that one event. There are other events. And the state.

====
Test:
curl -X POST -H "Content-Type: application/json"  --data '{"customer_location_id": "my-11th-location", "access_token": "abcd1234", "email": "some@email.com", "zipcode": "11111"}' https://${AS_HOST}/wirelessmesh/add-customer-location

Google Pubsub dump:
```
$ gcloud pubsub subscriptions pull wirelessmesh-feed --auto-ack
┌─────────────────────────────────────────────┬──────────────────┬──────────────────────────────────────────────────┐
│                     DATA                    │    MESSAGE_ID    │                    ATTRIBUTES                    │
├─────────────────────────────────────────────┼──────────────────┼──────────────────────────────────────────────────┤
│                                             │ 2326490729994933 │ ce-datacontenttype=application/protobuf          │
│ my-11th-locatioabcd1234some@email.com │                  │ ce-id=67fc65af-5284-42fa-9a7b-bfda86dfd770       │
│                                             │                  │ ce-source=publishing.PublishingService           │
│                                             │                  │ ce-specversion=1.0                               │
│                                             │                  │ ce-subject=my-11th-location                      │
│                                             │                  │ ce-time=2021-05-25T04:01:51.909583Z              │
│                                             │                  │ ce-type=wirelessmeshdomain.CustomerLocationAdded │
└─────────────────────────────────────────────┴──────────────────┴──────────────────────────────────────────────────┘
```




